### PR TITLE
Add DevOps to Sensitive information

### DIFF
--- a/policy/sensitive.yaml
+++ b/policy/sensitive.yaml
@@ -6,6 +6,7 @@ rules:
   - identities:
       groups:
         - Accounting
+        - DevOps
     reads:
       - data:
           - SENSITIVE


### PR DESCRIPTION
Add DevOps group to Sensitive fields since we split SRE and Developers into a third group